### PR TITLE
add getIndex(), pawn and knight move logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,9 @@ add_executable(Main
 		source/Piece.cpp
 		source/Piece.hpp
 		source/Square.cpp
-		source/Square.hpp)
+		source/Square.hpp
+		source/PieceController.hpp
+		source/PieceController.cpp)
 
 # Tests
 add_executable(BoardTest
@@ -25,5 +27,7 @@ add_executable(BoardTest
 		source/Piece.cpp
 		source/Piece.hpp
 		source/Square.cpp
-		source/Square.hpp)
+		source/Square.hpp
+		source/PieceController.hpp
+		source/PieceController.cpp)
 target_link_libraries(BoardTest TestRunner)

--- a/source/Board.cpp
+++ b/source/Board.cpp
@@ -59,15 +59,13 @@ Piece Board::getPieceByIndex(const int i, const int j)
 	return squares[i][j].getPiece();
 }
 
-/* Returns the the vector indices from a bord space. */
-int* Board::coordToIndex(std::string coords)
+
+// Converts board space name (e.g. "A1") to a tuple of vector indices ([i][j])
+std::tuple<int,int> Board::getIndex(std::string input)
 {
-	char let = coords[0];
-	char* num = &coords[1];
-	int indicies[2];
-	indicies[0] = let - 97;
-	indicies[1] = 8-std::atoi(num);
-	return indicies;
+	int column = input[0] - 97;
+	int row = 8 - (input[1] - 48);
+	return std::make_tuple(column, row);
 }
 
 // Places the appropriate pieces on the appropriate spots to start a chess game
@@ -86,11 +84,11 @@ void Board::setBoard()
 	Board::setPiece("c1", wb1);
 
 	// White King Placement
-	Piece wk{ KING , WHITE };
+	Piece wk{ QUEEN , WHITE };
 	Board::setPiece("d1", wk);
 
 	// White Queen Placement
-	Piece wq{ QUEEN ,WHITE };
+	Piece wq{ KING ,WHITE };
 	Board::setPiece("e1", wq);
 
 	// White Bishop Placement
@@ -136,11 +134,11 @@ void Board::setBoard()
 	Board::setPiece("c8", bb1);
 
 	// Black King Placement
-	Piece bk{ KING , BLACK };
+	Piece bk{ QUEEN , BLACK };
 	Board::setPiece("d8", bk);
 
 	// Black Queen Placement
-	Piece bq{ QUEEN , BLACK };
+	Piece bq{ KING , BLACK };
 	Board::setPiece("e8", bq);
 
 	// Black Bishop Placement
@@ -177,12 +175,12 @@ void Board::setBoard()
 	{
 		for (int j = 0; j < 8; j++)
 		{
-			if (squares[i][j].getPiece().getType() != NONE)
+			if (squares[i][j].getPiece().getType() != NOPIECE)
 			{
 				continue;
 			}
 			else {
-				Piece blankPiece{ NONE , OPEN };
+				Piece blankPiece{ NOPIECE , NOCOLOR };
 				squares[i][j].setPiece(blankPiece);
 			}
 		}

--- a/source/Board.hpp
+++ b/source/Board.hpp
@@ -4,6 +4,7 @@
 //#include <array>
 #include <vector>
 #include <map>
+#include <tuple>
 #include "Piece.hpp"
 #include "Square.hpp"
 
@@ -16,7 +17,7 @@ public:
 	void printBoard();
 	Piece getPiece(const std::string &coords);
 	void setPiece(const std::string &coords, Piece piece);
-	int* coordToIndex(std::string coords);
+	std::tuple<int, int> getIndex(std::string);
 	Piece getPieceByIndex(const int i, const int j);
 	~Board();
 private:

--- a/source/Piece.cpp
+++ b/source/Piece.cpp
@@ -60,7 +60,7 @@ char Piece::typeToChar(Type type) const
 		case ROOK: return 'R';
 		case QUEEN: return 'Q';
 		case KING: return 'K';
-		case NONE: return '-';
+		case NOPIECE: return '-';
 		default: return ' ';
 	}
 }
@@ -71,7 +71,7 @@ char Piece::colorToChar(Color color) const
 	{
 		case WHITE: return 'W';
 		case BLACK: return 'B';
-		case OPEN: return'-';
+		case NOCOLOR: return'-';
 		default: return ' ';
 	}
 }

--- a/source/Piece.hpp
+++ b/source/Piece.hpp
@@ -10,7 +10,7 @@
 // TODO: Added temporarily so I have something to work with.
 enum Type
 {
-	NONE,
+	NOPIECE,
 	PAWN,
 	KNIGHT,
 	BISHOP,
@@ -21,7 +21,7 @@ enum Type
 
 enum Color
 {
-	OPEN,
+	NOCOLOR,
 	WHITE,
 	BLACK
 };

--- a/source/PieceController.cpp
+++ b/source/PieceController.cpp
@@ -10,16 +10,13 @@ bool PieceController::movePiece(Board *B, std::string startCord, std::string end
 
 	Piece pieceCheck = B->getPiece(startCord);
 	if (pieceCheck.getColor() == player) {
-		bool moveCheck = false;
 		switch (pieceCheck.getType()) {
 		case PAWN:
-			moveCheck = movePawn(B, startCord, endCord, player);
-			return moveCheck;
+			return movePawn(B, startCord, endCord, player);
 		case ROOK:
-			moveCheck = moveRook(B, startCord, endCord, player);
-			break;
+			return moveRook(B, startCord, endCord, player);
 		case KNIGHT:
-			break;
+			return moveKnight(B, startCord, endCord, player);
 		case BISHOP:
 			break;
 		case QUEEN:
@@ -33,28 +30,127 @@ bool PieceController::movePiece(Board *B, std::string startCord, std::string end
 	return false;
 }
 
-bool PieceController::movePawn(Board* B, std::string startCord, std::string endCord, Color player) 
+bool PieceController::movePawn(Board* B, std::string start, std::string end, Color turn)
 {
+	// This code gets int values for start (X,Y) and end (X,Y)
+	std::tuple<int, int> from = B->getIndex(start);
+	std::tuple<int, int> to = B->getIndex(end);
+	int startX = std::get<0>(from);
+	int startY = std::get<1>(from);
+	int endX = std::get<0>(to);
+	int endY = std::get<1>(to);
+	
+	// Temporary print statements for testing
+	std::cout << "trying to move from " << start << " to " << end << std::endl;
+	std::cout << "converted to an index this is " << startY << "," << startX << " to " << endY << "," << endX << std::endl;
 
-	makeMove(B, startCord, endCord, player);
-	return false;
+	if (turn == WHITE)
+	{
+		// Check possible move types
+		// 1) Moving forward one square, and that square is unoccupied
+		if ((startX == endX) && (startY == endY + 1) && (B->getPiece(end).getType() == NOPIECE))
+		{
+			makeMove(B, start, end, turn);
+			return true;
+		}
+		// 2) Moving forward two squares (if pawn hasn't yet moved, and end square is unoccupied)
+		else if ((startX == endX) && (startY == endY + 2) && ((B->getPiece(start).getMoved() == false)) && (B->getPiece(end).getType() == NOPIECE))
+		{
+			makeMove(B, start, end, turn);
+			return true;
+		}
+		// 3) Moving diagonally/forward one square, and capturing enemy piece
+		else if ((startY == endY + 1) && (startX == endX - 1 || startX == endX + 1) && ((B->getPiece(end).getColor() != turn) && B->getPiece(end).getColor() != NOCOLOR))
+		{
+			makeMove(B, start, end, turn);
+			return true;
+		}
+
+		// If not one of the legal moves above, print error and return false
+		std::cout << "Not a legal move." << std::endl << std::endl;
+		return false;
+	}
+	// Same thing for BLACK turn (how to reduce this duplication?)
+	else if (turn == BLACK)
+	{
+		if ((startX == endX) && (startY == endY - 1) && (B->getPiece(end).getType() == NOPIECE))
+		{
+			makeMove(B, start, end, turn);
+			return true;
+		}
+		else if ((startX == endX) && (startY == endY - 2) && ((B->getPiece(start).getMoved() == false)) && (B->getPiece(end).getType() == NOPIECE))
+		{
+			makeMove(B, start, end, turn);
+			return true;
+		}
+		else if ((startY == endY - 1) && (startX == endX - 1 || startX == endX + 1) && ((B->getPiece(end).getColor() != turn) && B->getPiece(end).getColor() != NOCOLOR))
+		{
+			makeMove(B, start, end, turn);
+			return true;
+		}
+		std::cout << "Not a legal move." << std::endl << std::endl;
+		return false;
+
+	}
 };
+
 bool PieceController::attackPawn(Board* B, std::string startCord, std::string endCord, Color player) 
 {
 
 	return false;
 }
+
+
+// There are eight possible knight moves: two squares in one direction, and one square perpendicularly
+bool PieceController::moveKnight(Board* B, std::string start, std::string end, Color turn)
+{
+	std::tuple<int, int> from = B->getIndex(start);
+	std::tuple<int, int> to = B->getIndex(end);
+	int startX = std::get<0>(from);
+	int startY = std::get<1>(from);
+	int endX = std::get<0>(to);
+	int endY = std::get<1>(to);
+
+	// Temporary print statements for testing
+	std::cout << "trying to move from " << start << " to " << end << std::endl;
+	std::cout << "converted to an index this is " << startY << "," << startX << " to " << endY << "," << endX << std::endl;
+
+	if (((startY == endY - 2) || (startY == endY + 2)) && ((startX == endX - 1) || (startX == endX + 1)) && (B->getPiece(end).getColor() != turn))
+	{
+		makeMove(B, start, end, turn);
+		return true;
+	}
+	else if (((startX == endX - 2) || (startX == endX + 2)) && ((startY == endY - 1) || (startY == endY + 1)) && (B->getPiece(end).getColor() != turn))
+	{
+		makeMove(B, start, end, turn);
+		return true;
+	}
+
+	std::cout << "Not a valid move." << std::endl;
+	return false;
+}
+
+
+
 bool PieceController::moveRook(Board* B, std::string startCord, std::string endCord, Color player) 
 {
 
 	// Check that either row or column are the same
-	int startRow, startCol, endRow, endCol;
-	int* start = B->coordToIndex(startCord);
-	startCol = start[0];
-	startRow = start[1];
-	int* end = B->coordToIndex(endCord);
-	endCol = end[0];
-	endRow = end[1];
+	//int startRow, startCol, endRow, endCol;
+	//int* start = B->coordToIndex(startCord);
+	//startCol = start[0];
+	//startRow = start[1];
+	//int* end = B->coordToIndex(endCord);
+	//endCol = end[0];
+	//endRow = end[1];
+
+	std::tuple<int, int> from = B->getIndex(startCord);
+	std::tuple<int, int> to = B->getIndex(endCord);
+	int startCol = std::get<0>(from);
+	int startRow = std::get<1>(from);
+	int endCol = std::get<0>(to);
+	int endRow = std::get<1>(to);
+
 
 	// Check that destination square is open
 	if (B->getPiece(endCord).getColor() == player) {
@@ -69,7 +165,7 @@ bool PieceController::moveRook(Board* B, std::string startCord, std::string endC
 		{
 			for (int i = startCol - 1; i < endCol + 1; i--)
 			{
-				if (B->getPiece(endCord).getType() != NONE) {
+				if (B->getPiece(endCord).getType() != NOPIECE) {
 					return false; //piece in the way
 				}
 			}
@@ -84,7 +180,7 @@ bool PieceController::moveRook(Board* B, std::string startCord, std::string endC
 		{
 			for (int i = startCol + 1; i < endCol - 1; i++)
 			{
-				if (B->getPieceByIndex(startCol, i).getType() != NONE) {
+				if (B->getPieceByIndex(startCol, i).getType() != NOPIECE) {
 					return false; //piece in the way
 				}
 			}
@@ -106,7 +202,7 @@ bool PieceController::moveRook(Board* B, std::string startCord, std::string endC
 		{
 			for (int i = startRow-1; i < endRow+1; i--) 
 			{
-				if (B->getPieceByIndex(i, endCol).getType() != NONE) {
+				if (B->getPieceByIndex(i, endCol).getType() != NOPIECE) {
 					return false; //piece in the way
 				}
 			}
@@ -121,7 +217,7 @@ bool PieceController::moveRook(Board* B, std::string startCord, std::string endC
 		{
 			for (int i = startRow; i < endRow-1; i++)
 			{
-				if (B->getPieceByIndex(i, endCol).getType() != NONE) {
+				if (B->getPieceByIndex(i, endCol).getType() != NOPIECE) {
 					return false; //piece in the way
 				}
 
@@ -136,10 +232,8 @@ bool PieceController::moveRook(Board* B, std::string startCord, std::string endC
 	// Invalid Move
 	return false;
 }
-bool PieceController::moveKnight(Board* B, std::string startCord, std::string endCord, Color player) 
-{
-	return false;
-}
+
+
 bool PieceController::moveBishop(Board* B, std::string startCord, std::string endCord, Color player) 
 {
 	return false;
@@ -153,6 +247,6 @@ void PieceController::makeMove(Board* B, std::string startCord, std::string endC
 {
 	Piece moving = B->getPiece(startCord);
 	B->setPiece(endCord, moving);
-	Piece empty = Piece(NONE, OPEN);
+	Piece empty = Piece(NOPIECE, NOCOLOR);
 	B->setPiece(startCord, empty);
 }

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -1,12 +1,21 @@
 #include <iostream>
 #include "Board.hpp"
+#include "PieceController.hpp"
 
 using std::cout;
 using std::endl;
 
 int main()
 {
-	Board board;
-	board.printBoard();
+	Board B;
+	PieceController P;
+
+	P.movePiece(&B, "a2", "a4", WHITE);
+
+	P.movePiece(&B, "b8", "c6", BLACK);
+
+	P.movePiece(&B, "a1", "a3", WHITE);
+
+	B.printBoard();
 	return 0;
 }


### PR DESCRIPTION
- Added getIndex() which takes a space name e.g. "a1" and returns a tuple with the vector indices 0, 7.
- Changed "empty" Piece type and Color enums to NOPIECE and NOCOLOR for clarity
- Corrected King and Queen placement
- Simplified pieceController switch case returns
- Added movePawn() and moveKnight() functions
- Adjusted moveRook() to use the new getIndex() function