### PR TITLE
Fix and improve movement logic

### DIFF
--- a/source/Board.hpp
+++ b/source/Board.hpp
@@ -19,11 +19,13 @@ public:
 
 	// General
 	void printBoard();
-	const Piece* getPiece(const std::pair<int, int> &coords) const;
+	Piece* getPiece(const std::pair<int, int> &coords) const;
 	bool movePiece(const std::pair<int, int> &fromCoords, const std::pair<int, int> &toCoords);
 
 	// Board and movement attributes
 	bool isOccupied(const std::pair<int, int> &coords) const;
+	bool isOccupiedSameColor(const std::pair<int, int> &fromCoords, const std::pair<int, int> &toCoords) const;
+	bool isOccupiedDifferentColor(const std::pair<int, int> &fromCoords, const std::pair<int, int> &toCoords) const;
 	bool isVerticalMove(const std::pair<int, int> &fromCoords, const std::pair<int, int> &toCoords) const;
 	bool isHorizontalMove(const std::pair<int, int> &fromCoords, const std::pair<int, int> &toCoords) const;
 	bool isDiagonalMove(const std::pair<int, int> &fromCoords, const std::pair<int, int> &toCoords) const;

--- a/source/Pawn.cpp
+++ b/source/Pawn.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include "Pawn.hpp"
 
-// Constructor
+/* Constructor */
 Pawn::Pawn(Color c) : Piece(PAWN, c) {}
 
 /* Determine if this is a valid move based on the rules of the pawn. */
@@ -28,7 +28,7 @@ bool Pawn::isValidMove(const Board *board, const std::pair<int, int> &fromCoords
 		// Is 1 step?
 		if (moveLength == 1)
 		{
-			if (board->isOccupied(toCoords) && board->getPiece(fromCoords)->getColor() != board->getPiece(toCoords)->getColor())
+			if (board->isOccupiedDifferentColor(fromCoords, toCoords))
 			{
 				// Capture!
 				return true;

--- a/source/Square.cpp
+++ b/source/Square.cpp
@@ -2,7 +2,7 @@
 #include <memory>
 #include "Square.hpp"
 
-const Piece* Square::getPiece() const
+Piece* Square::getPiece() const
 {
 	return piece.get();
 }

--- a/source/Square.hpp
+++ b/source/Square.hpp
@@ -9,7 +9,7 @@
 class Square
 {
 public:
-	const Piece* getPiece() const;
+	Piece* getPiece() const;
 	std::unique_ptr<Piece> setPiece(std::unique_ptr<Piece> piece);
 protected:
 	std::unique_ptr<Piece> piece;


### PR DESCRIPTION
- Changed specifier for getPiece()
- Create extra functions for occupied by same or different color

Noticed a problem with pawn movement, namely that a pawn was able to
move one square and then move again two squares. Problem was that the
moved member variable for pawn wasn't being updated. So, modified
getPiece (removing const specifier) so that moved could be modified.

Moving a piece to a location occupied by a piece of the same color is
never allowed, so that check now takes place at the Board level before
calling an individual piece's isValidMove function. For specific piece
types, you can either call isOccupied if the color doesn't matter (as in
a pawn that has a piece in front of it) or isOccupiedDifferentColor to
check for an attack (for example).