### PR TITLE
Fix error in diagonal clear path

### DIFF
--- a/source/Board.cpp
+++ b/source/Board.cpp
@@ -381,13 +381,6 @@ bool Board::isPathClear(const std::pair<int, int> &fromCoords, const std::pair<i
 	bool movingSouth = fromCoords.first < toCoords.first; 			// "south" meaning from black side to white side
 	bool movingEast = fromCoords.second < toCoords.second;			// "east" meaning from white left to white right
 
-	// Check if the destination has a friendly piece; if so, we can't move there
-	if (isOccupied(toCoords) && (getPiece(fromCoords)->getColor() == getPiece(toCoords)->getColor()))
-	{
-		std::cout << "Invalid move (friendly piece at destination)." << std::endl;
-		return false;
-	}
-
 	// If same or adjacent location, then path is definitely clear
 	if (moveLength == 0 || moveLength == 1)
 	{
@@ -445,14 +438,14 @@ bool Board::isPathClear(const std::pair<int, int> &fromCoords, const std::pair<i
 				std::swap(fromTemp, toTemp);
 			}
 
-			int j = fromTemp.second + 1;
-			for (int i = fromTemp.first + 1; i < toTemp.first; i++)
+			int col = fromTemp.second + 1;
+			for (int row = fromTemp.first + 1; row < toTemp.first; row++)
 			{
-				if (isOccupied(std::make_pair(i, j)))
+				if (isOccupied(std::make_pair(row, col)))
 				{
 					return false;
 				}
-				j++;
+				col++;
 			}
 
 			// Checked all intermediate locations and found them to be empty, so can return true
@@ -467,12 +460,14 @@ bool Board::isPathClear(const std::pair<int, int> &fromCoords, const std::pair<i
 				std::swap(fromTemp, toTemp);
 			}
 
-			for (int i = fromTemp.first + 1; i < toTemp.first; i++)
+			int col = fromTemp.second + 1;
+			for (int row = fromTemp.first - 1; row > toTemp.first; row--)
 			{
-				if (isOccupied(std::make_pair(i, 7 - i)))
+				if (isOccupied(std::make_pair(row, col)))
 				{
 					return false;
 				}
+				col++;
 			}
 
 			// Checked all intermediate locations and found them to be empty, so can return true

--- a/test/BoardTest.cpp
+++ b/test/BoardTest.cpp
@@ -9,23 +9,23 @@ TEST_CASE("Move types")
 	Board board;
 
 	// Vertical moves
-	REQUIRE(board.isVerticalMove(std::make_pair(0,0), std::make_pair(0,0)) == true);
-	REQUIRE(board.isVerticalMove(std::make_pair(3,2), std::make_pair(0,2)) == true);
-	REQUIRE(board.isVerticalMove(std::make_pair(0,0), std::make_pair(4,0)) == true);
-	REQUIRE(board.isVerticalMove(std::make_pair(3,2), std::make_pair(1,4)) == false);
+	CHECK(board.isVerticalMove(std::make_pair(0,0), std::make_pair(0,0)) == true);
+	CHECK(board.isVerticalMove(std::make_pair(3,2), std::make_pair(0,2)) == true);
+	CHECK(board.isVerticalMove(std::make_pair(0,0), std::make_pair(4,0)) == true);
+	CHECK(board.isVerticalMove(std::make_pair(3,2), std::make_pair(1,4)) == false);
 
 	// Horizontal moves
-	REQUIRE(board.isHorizontalMove(std::make_pair(0,0), std::make_pair(0,0)) == true);
-	REQUIRE(board.isHorizontalMove(std::make_pair(2,0), std::make_pair(2,4)) == true);
-	REQUIRE(board.isHorizontalMove(std::make_pair(3,4), std::make_pair(3,0)) == true);
-	REQUIRE(board.isHorizontalMove(std::make_pair(4,0), std::make_pair(0,4)) == false);
+	CHECK(board.isHorizontalMove(std::make_pair(0,0), std::make_pair(0,0)) == true);
+	CHECK(board.isHorizontalMove(std::make_pair(2,0), std::make_pair(2,4)) == true);
+	CHECK(board.isHorizontalMove(std::make_pair(3,4), std::make_pair(3,0)) == true);
+	CHECK(board.isHorizontalMove(std::make_pair(4,0), std::make_pair(0,4)) == false);
 
 	// Diagonal moves
-	REQUIRE(board.isDiagonalMove(std::make_pair(0,0), std::make_pair(0,0)) == true);
-	REQUIRE(board.isDiagonalMove(std::make_pair(0,0), std::make_pair(4,4)) == true);
-	REQUIRE(board.isDiagonalMove(std::make_pair(0,0), std::make_pair(0,2)) == false);
-	REQUIRE(board.isDiagonalMove(std::make_pair(0,0), std::make_pair(3,0)) == false);
-	REQUIRE(board.isDiagonalMove(std::make_pair(0,2), std::make_pair(4,1)) == false);
+	CHECK(board.isDiagonalMove(std::make_pair(0,0), std::make_pair(0,0)) == true);
+	CHECK(board.isDiagonalMove(std::make_pair(0,0), std::make_pair(4,4)) == true);
+	CHECK(board.isDiagonalMove(std::make_pair(0,0), std::make_pair(0,2)) == false);
+	CHECK(board.isDiagonalMove(std::make_pair(0,0), std::make_pair(3,0)) == false);
+	CHECK(board.isDiagonalMove(std::make_pair(0,2), std::make_pair(4,1)) == false);
 }
 
 TEST_CASE("Move lengths")
@@ -33,59 +33,59 @@ TEST_CASE("Move lengths")
 	Board board;
 
 	// Vertical move lengths
-	REQUIRE(board.getMoveLength(std::make_pair(0,0), std::make_pair(0,0)) == 0);
-	REQUIRE(board.getMoveLength(std::make_pair(0,0), std::make_pair(4,0)) == 4);
+	CHECK(board.getMoveLength(std::make_pair(0,0), std::make_pair(0,0)) == 0);
+	CHECK(board.getMoveLength(std::make_pair(0,0), std::make_pair(4,0)) == 4);
 
 	// Horizontal move lengths
-	REQUIRE(board.getMoveLength(std::make_pair(0,0), std::make_pair(0,0)) == 0);
-	REQUIRE(board.getMoveLength(std::make_pair(0,0), std::make_pair(3,0)) == 3);
+	CHECK(board.getMoveLength(std::make_pair(0,0), std::make_pair(0,0)) == 0);
+	CHECK(board.getMoveLength(std::make_pair(0,0), std::make_pair(3,0)) == 3);
 
 	// Diagonal move lengths
-	REQUIRE(board.getMoveLength(std::make_pair(0,0), std::make_pair(0,0)) == 0);
-	REQUIRE(board.getMoveLength(std::make_pair(3,3), std::make_pair(1,1)) == 2);
+	CHECK(board.getMoveLength(std::make_pair(0,0), std::make_pair(0,0)) == 0);
+	CHECK(board.getMoveLength(std::make_pair(3,3), std::make_pair(1,1)) == 2);
 }
 
-TEST_CASE("Clear and obstructed paths")
+TEST_CASE("Starting board clear and obstructed paths")
 {
 	Board board;
 
-	// TODO: These tests depend on a board only populated with pawns. As we add more pieces to our constructor for
-	// 		Board, these tests will no longer be accurate.
-
 	// Clear paths
-	REQUIRE(board.isPathClear(std::make_pair(0,0), std::make_pair(0,0)) == true); // same location
-	REQUIRE(board.isPathClear(std::make_pair(1,0), std::make_pair(1,1)) == true); // adjacent location
-	REQUIRE(board.isPathClear(std::make_pair(1,3), std::make_pair(6,3)) == true);	// N->S vertical
-	REQUIRE(board.isPathClear(std::make_pair(0,0), std::make_pair(0,7)) == true); // W->E horizontal
-	REQUIRE(board.isPathClear(std::make_pair(2,2), std::make_pair(5,5)) == true); // NW->SE diagonal
-	REQUIRE(board.isPathClear(std::make_pair(5,5), std::make_pair(2,2)) == true); // SE->NW diagonal
-	REQUIRE(board.isPathClear(std::make_pair(6,6), std::make_pair(1,1)) == true); // SE->NW diagonal
-	REQUIRE(board.isPathClear(std::make_pair(1,1), std::make_pair(6,6)) == true); // NW->SE diagonal
-	REQUIRE(board.isPathClear(std::make_pair(6,1), std::make_pair(1,6)) == true); // SW->NE diagonal
+	CHECK(board.isPathClear(std::make_pair(0,0), std::make_pair(0,0)) == true); 	// same location
+	CHECK(board.isPathClear(std::make_pair(1,0), std::make_pair(1,1)) == true); 	// adjacent location
+	CHECK(board.isPathClear(std::make_pair(1,3), std::make_pair(5,3)) == true);	// N->S vertical
+	CHECK(board.isPathClear(std::make_pair(2,0), std::make_pair(2,7)) == true); 	// W->E horizontal
+	CHECK(board.isPathClear(std::make_pair(2,2), std::make_pair(5,5)) == true); 	// NW->SE diagonal
+	CHECK(board.isPathClear(std::make_pair(5,5), std::make_pair(2,2)) == true); 	// SE->NW diagonal
+	CHECK(board.isPathClear(std::make_pair(2,2), std::make_pair(5,5)) == true); 	// NW->SE diagonal
+	CHECK(board.isPathClear(std::make_pair(5,1), std::make_pair(3,3)) == true); 	// SW->NE diagonal
+	CHECK(board.isPathClear(std::make_pair(5,0), std::make_pair(2,3)) == true); 	// off-center diagonal
+	CHECK(board.isPathClear(std::make_pair(4,6), std::make_pair(2,4)) == true); 	// off-center diagonal
 
 	// Obstructed paths
-	REQUIRE(board.isPathClear(std::make_pair(0,2), std::make_pair(2,2)) == false); // N->S vertical
-	REQUIRE(board.isPathClear(std::make_pair(0,3), std::make_pair(7,3)) == false); // N->S vertical
-	REQUIRE(board.isPathClear(std::make_pair(1,0), std::make_pair(1,2)) == false); // W->E horizontal
-	REQUIRE(board.isPathClear(std::make_pair(0,0), std::make_pair(7,7)) == false); // NW->SE diagonal
-	REQUIRE(board.isPathClear(std::make_pair(7,7), std::make_pair(0,0)) == false); // SE->NW diagonal
-	REQUIRE(board.isPathClear(std::make_pair(7,0), std::make_pair(0,7)) == false); // SW->NE diagonal
-	REQUIRE(board.isPathClear(std::make_pair(3,2), std::make_pair(4,7)) == false); // not vertical, horizontal, nor diagonal
+	CHECK(board.isPathClear(std::make_pair(0,2), std::make_pair(2,2)) == false); 	// N->S vertical
+	CHECK(board.isPathClear(std::make_pair(0,3), std::make_pair(7,3)) == false); 	// N->S vertical
+	CHECK(board.isPathClear(std::make_pair(1,0), std::make_pair(1,2)) == false); 	// W->E horizontal
+	CHECK(board.isPathClear(std::make_pair(0,0), std::make_pair(7,7)) == false); 	// NW->SE diagonal
+	CHECK(board.isPathClear(std::make_pair(7,7), std::make_pair(0,0)) == false); 	// SE->NW diagonal
+	CHECK(board.isPathClear(std::make_pair(7,0), std::make_pair(0,7)) == false); 	// SW->NE diagonal
+	CHECK(board.isPathClear(std::make_pair(3,7), std::make_pair(0,4)) == false); 	// off-center diagonal
+	CHECK(board.isPathClear(std::make_pair(4,6), std::make_pair(7,3)) == false); 	// off-center diagonal
+	CHECK(board.isPathClear(std::make_pair(3,2), std::make_pair(4,7)) == false); 	// not vertical, horizontal, nor diagonal
 }
 
-TEST_CASE("Foreward moves")
+TEST_CASE("Forward moves")
 {
 	Board board;
 	const Piece *whitePawn = board.getPiece(std::make_pair(6,7));
 	const Piece *blackPawn = board.getPiece(std::make_pair(1,7));
 
 	// Forward movement
-	REQUIRE(board.isForwardMove(std::make_pair(6,7), std::make_pair(5,7), whitePawn) == true);
-	REQUIRE(board.isForwardMove(std::make_pair(1,7), std::make_pair(2,7), blackPawn) == true);
+	CHECK(board.isForwardMove(std::make_pair(6,7), std::make_pair(5,7), whitePawn) == true);
+	CHECK(board.isForwardMove(std::make_pair(1,7), std::make_pair(2,7), blackPawn) == true);
 
 	// Backward movement
-	REQUIRE(board.isForwardMove(std::make_pair(6,7), std::make_pair(7,7), whitePawn) == false);
-	REQUIRE(board.isForwardMove(std::make_pair(1,7), std::make_pair(0,7), blackPawn) == false);
+	CHECK(board.isForwardMove(std::make_pair(6,7), std::make_pair(7,7), whitePawn) == false);
+	CHECK(board.isForwardMove(std::make_pair(1,7), std::make_pair(0,7), blackPawn) == false);
 }
 
 TEST_CASE("Pawn moves")


### PR DESCRIPTION
Tony previously found and fixed an error regarding checking whether
diagonal paths are clear. This commit extends that fix to the other
diagonal direction and updates unit tests to match. Also renames i and j
to row and col, respectively.

Also moved the testing cases to CHECK rather than REQUIRE. CHECK will
allow other tests to occur, whereas if a REQUIRE fails then computation
is stopped and no other tests are run.

Finally, whether or not a path is clear has nothing to do with whether the destination is a friendly or non-friendly piece. Indeed, it doesn't check the destination at all. So I've removed that block in isPathClear().