### PR TITLE
Silence compiler warnings

### DIFF
--- a/source/Bishop.cpp
+++ b/source/Bishop.cpp
@@ -7,8 +7,6 @@ Bishop::Bishop(Color c) : Piece(BISHOP, c) {}
 /* Determine if this is a valid move based on the rules of the Bishop. */
 bool Bishop::isValidMove(const Board *board, const std::pair<int, int> &fromCoords, const std::pair<int, int> &toCoords) const
 {
-	int moveLength = board->getMoveLength(fromCoords, toCoords);
-
 	if (board->isDiagonalMove(fromCoords, toCoords))
 	{
 		if (board->isPathClear(fromCoords, toCoords))

--- a/source/Board.cpp
+++ b/source/Board.cpp
@@ -400,6 +400,8 @@ int Board::getMoveLength(const std::pair<int, int> &fromCoords, const std::pair<
 bool Board::isValidCastle(const std::pair<int, int>& fromCoords, const std::pair<int, int>& toCoords) const
 {
 	// TODO: Implement castling
+	(void)fromCoords; 	// silence compiler warnings until this function is actually implemented
+	(void)toCoords; 	// silence compiler warnings until this function is actually implemented
 	return false;
 }
 


### PR DESCRIPTION
- Removed unused variable from Bishop::isValidMove()
- Used (void) on parameters in Board::isValidCastle()